### PR TITLE
Add measurements to ConnectorStatus

### DIFF
--- a/chargeamps/base.py
+++ b/chargeamps/base.py
@@ -37,11 +37,20 @@ class ChargePoint(object):
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass(frozen=True)
+class ChargePointMeasurement(object):
+    phase: str
+    current: float
+    voltage: float
+
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass(frozen=True)
 class ChargePointConnectorStatus(object):
     charge_point_id: str
     connector_id: int
     total_consumption_kwh: float
     status: str
+    measurements: Optional[List[ChargePointMeasurement]]
     start_time: Optional[datetime] = datetime_field()
     end_time: Optional[datetime] = datetime_field()
     session_id: Optional[str] = None


### PR DESCRIPTION
I would like to display active phase and current Watt usage, this enables that. (There will be another PR in the HA code later.)


Example output:
`python -m chargeamps.cli --config examples/config.json status`

```json
{
    "id": "170xxxx294",
    "status": "Online",
    "connectorStatuses": [
        {
            "chargePointId": "170xxxx294",
            "connectorId": 1,
            "totalConsumptionKwh": 0.20925498008728027,
            "status": "Charging",
            "measurements": [
                {
                    "phase": "L1",
                    "current": 0.0,
                    "voltage": 244.821
                },
                {
                    "phase": "L2",
                    "current": 0.0,
                    "voltage": 0.0
                },
                {
                    "phase": "L3",
                    "current": 12.644623,
                    "voltage": 244.821
                }
            ],
            "startTime": null,
            "endTime": null,
            "sessionId": null
        },
        {
            "chargePointId": "170xxxx294",
            "connectorId": 2,
            "totalConsumptionKwh": 0.0,
            "status": "Available",
            "measurements": null,
            "startTime": null,
            "endTime": null,
            "sessionId": null
        }
    ]
}
```
