### PR TITLE
Remove asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     packages=['chargeamps'],
     install_requires=[
         'aiohttp',
-        'asyncio',
         'dataclasses',
         'dataclasses-json',
         'isodate',


### PR DESCRIPTION
`asyncio` is a standard module.

Is blocking the [review request](https://bugzilla.redhat.com/show_bug.cgi?id=1880433) for the Fedora Package Collection.