### PR TITLE
Add Python release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'aiohttp',
         'asyncio',
-        'dataclasses',
+        'dataclasses;python_version<"3.7"',
         'dataclasses-json',
         'isodate',
         'marshmallow',


### PR DESCRIPTION
`dataclasses` is a default module since 3.7. The requirement here is only needed for [Python < 3.7](https://docs.python.org/3/library/dataclasses.html).

This is also related to the [review request](https://bugzilla.redhat.com/show_bug.cgi?id=1880433) for the Fedora Package Collection. Will affect other distributions as well.