### PR TITLE
Use importlib_metadata for getting the version

### DIFF
--- a/chargeamps/__init__.py
+++ b/chargeamps/__init__.py
@@ -1,3 +1,3 @@
-from importlib_metadata import version
+from importlib.metadata import version
 
 __version__ = version("chargeamps")

--- a/chargeamps/__init__.py
+++ b/chargeamps/__init__.py
@@ -1,3 +1,3 @@
-import pkg_resources
+from importlib_metadata import version
 
-__version__ = pkg_resources.get_distribution("chargeamps").version
+__version__ = version("chargeamps")


### PR DESCRIPTION
It seems with python 3.11 pkg_resources is deprecated: https://setuptools.pypa.io/en/latest/pkg_resources.html

When releasing python-chargeamps make sure to bump it in the hass-chargeamps repo and make a new release as this is needed for the latest version of home-assistant.