### PR TITLE
Add remote start/stop using RFID

### DIFF
--- a/chargeamps/base.py
+++ b/chargeamps/base.py
@@ -93,3 +93,11 @@ class ChargingSession(object):
     total_consumption_kwh: float
     start_time: Optional[datetime] = datetime_field()
     end_time: Optional[datetime] = datetime_field()
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass(frozen=True)
+class StartAuth(object):
+    rfidLength: int
+    rfidFormat: str
+    rfid: str
+    externalTransactionId: str

--- a/chargeamps/base.py
+++ b/chargeamps/base.py
@@ -94,6 +94,7 @@ class ChargingSession(object):
     start_time: Optional[datetime] = datetime_field()
     end_time: Optional[datetime] = datetime_field()
 
+
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass(frozen=True)
 class StartAuth(object):

--- a/chargeamps/base.py
+++ b/chargeamps/base.py
@@ -97,7 +97,7 @@ class ChargingSession(object):
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass(frozen=True)
 class StartAuth(object):
-    rfidLength: int
-    rfidFormat: str
+    rfid_length: int
+    rfid_format: str
     rfid: str
-    externalTransactionId: str
+    external_transaction_id: str

--- a/chargeamps/external.py
+++ b/chargeamps/external.py
@@ -16,7 +16,7 @@ from .base import (
     ChargePointSettings,
     ChargePointStatus,
     ChargingSession,
-    StartAuth
+    StartAuth,
 )
 
 API_BASE_URL = "https://eapi.charge.space"
@@ -155,14 +155,13 @@ class ChargeAmpsExternalClient(ChargeAmpsClient):
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/settings"
         await self._put(request_uri, json=payload)
 
-    async def remote_start(self, charge_point_id: str, connector_id: int, startAuth: StartAuth) -> None:
+    async def remote_start(self, charge_point_id: str, connector_id: int, start_auth: StartAuth) -> None:
         """Remote start chargepoint"""
-        payload = startAuth.to_dict()
+        payload = start_auth.to_dict()
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/remotestart"
         await self._put(request_uri, json=payload)
 
-    async def remote_stop(self, charge_point_id: str, connector_id: int, startAuth: StartAuth) -> None:
-        """Remote start chargepoint"""
-        payload = startAuth.to_dict()
+    async def remote_stop(self, charge_point_id: str, connector_id: int) -> None:
+        """Remote stop chargepoint"""
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/remotestop"
-        await self._put(request_uri, json=payload)
+        await self._put(request_uri)

--- a/chargeamps/external.py
+++ b/chargeamps/external.py
@@ -16,6 +16,7 @@ from .base import (
     ChargePointSettings,
     ChargePointStatus,
     ChargingSession,
+    StartAuth
 )
 
 API_BASE_URL = "https://eapi.charge.space"
@@ -152,4 +153,16 @@ class ChargeAmpsExternalClient(ChargeAmpsClient):
         charge_point_id = settings.charge_point_id
         connector_id = settings.connector_id
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/settings"
+        await self._put(request_uri, json=payload)
+
+    async def remote_start(self, charge_point_id: str, connector_id: int, startAuth: StartAuth) -> None:
+        """Remote start chargepoint"""
+        payload = startAuth.to_dict()
+        request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/remotestart"
+        await self._put(request_uri, json=payload)
+
+    async def remote_stop(self, charge_point_id: str, connector_id: int, startAuth: StartAuth) -> None:
+        """Remote start chargepoint"""
+        payload = startAuth.to_dict()
+        request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/remotestop"
         await self._put(request_uri, json=payload)

--- a/chargeamps/external.py
+++ b/chargeamps/external.py
@@ -155,7 +155,9 @@ class ChargeAmpsExternalClient(ChargeAmpsClient):
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/settings"
         await self._put(request_uri, json=payload)
 
-    async def remote_start(self, charge_point_id: str, connector_id: int, start_auth: StartAuth) -> None:
+    async def remote_start(
+        self, charge_point_id: str, connector_id: int, start_auth: StartAuth
+    ) -> None:
         """Remote start chargepoint"""
         payload = start_auth.to_dict()
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/remotestart"


### PR DESCRIPTION
Allow Remote Start/Stop using RFID which is a requirement if OCPP is enabled.

Endpoints: PUT
[/api/v4/chargepoints/{chargePointId}/connectors/{connectorId}/remotestart](https://eapi.charge.space/swagger/index.html#/ChargePoint/ChargePoint_RemoteStart)
Re

PUT
[/api/v4/chargepoints/{chargePointId}/connectors/{connectorId}/remotestop](https://eapi.charge.space/swagger/index.html#/ChargePoint/ChargePoint_RemoteStop)