### PR TITLE
Allow None firmware and hardware versions

### DIFF
--- a/chargeamps/models.py
+++ b/chargeamps/models.py
@@ -33,8 +33,8 @@ class ChargePoint(FrozenBaseSchema):
     password: str
     type: str
     is_loadbalanced: bool
-    firmware_version: str
-    hardware_version: str
+    firmware_version: str | None = None
+    hardware_version: str | None = None
     connectors: list[ChargePointConnector]
 
 


### PR DESCRIPTION
Api may not include firmware_version or hardware_version.
Accept None entry on firmware and hardware vesions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing firmware and hardware version info for charge points: the app no longer errors when these values are unavailable and will show them as unknown/blank where appropriate, ensuring more reliable behavior across devices and smoother display and integrations that reference device version details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->