### PR TITLE
Allow None down_light (Only available in Halo)

### DIFF
--- a/chargeamps/models.py
+++ b/chargeamps/models.py
@@ -64,7 +64,7 @@ class ChargePointStatus(FrozenBaseSchema):
 class ChargePointSettings(FrozenBaseSchema):
     id: str
     dimmer: str
-    down_light: bool
+    down_light: bool | None = None
 
 
 class ChargePointConnectorSettings(FrozenBaseSchema):


### PR DESCRIPTION
Only Halo has down_light, thus the API will return None on other products.
Accept None entry on down_light.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The “Down Light” option in Charge Point settings is now optional. You can omit it or explicitly set it to “None” when configuring or reading settings, instead of always providing true/false.
  - This improves flexibility and compatibility with devices or integrations that don’t report or use this option.
  - Reduces configuration and validation errors when the down-light capability is unavailable or intentionally left unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->